### PR TITLE
Improve student SVG eyes

### DIFF
--- a/img/boy_angry.svg
+++ b/img/boy_angry.svg
@@ -1,8 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <circle cx="32" cy="32" r="30" fill="#FFE0BD" stroke="#000" stroke-width="2"/>
   <path d="M10 18 Q32 -6 54 18" fill="#333"/>
-  <circle cx="22" cy="30" r="4" fill="#000"/>
-  <circle cx="42" cy="30" r="4" fill="#000"/>
+  <circle cx="22" cy="30" r="5" fill="#FFF"/>
+  <circle cx="22" cy="30" r="2" fill="#000"/>
+  <circle cx="42" cy="30" r="5" fill="#FFF"/>
+  <circle cx="42" cy="30" r="2" fill="#000"/>
   <path d="M18 24 l8 -4" stroke="#000" stroke-width="3" stroke-linecap="round"/>
   <path d="M46 24 l-8 -4" stroke="#000" stroke-width="3" stroke-linecap="round"/>
   <path d="M20 48 q12 -8 24 0" stroke="#000" stroke-width="3" fill="none" stroke-linecap="round"/>

--- a/img/boy_calm.svg
+++ b/img/boy_calm.svg
@@ -1,7 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <circle cx="32" cy="32" r="30" fill="#FFE0BD" stroke="#000" stroke-width="2"/>
   <path d="M10 18 Q32 -6 54 18" fill="#333"/>
-  <circle cx="22" cy="30" r="4" fill="#000"/>
-  <circle cx="42" cy="30" r="4" fill="#000"/>
+  <circle cx="22" cy="30" r="5" fill="#FFF"/>
+  <circle cx="22" cy="30" r="2" fill="#000"/>
+  <circle cx="42" cy="30" r="5" fill="#FFF"/>
+  <circle cx="42" cy="30" r="2" fill="#000"/>
   <line x1="22" y1="44" x2="42" y2="44" stroke="#000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/img/boy_joy.svg
+++ b/img/boy_joy.svg
@@ -1,7 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <circle cx="32" cy="32" r="30" fill="#FFE0BD" stroke="#000" stroke-width="2"/>
   <path d="M10 18 Q32 -6 54 18" fill="#333"/>
-  <circle cx="22" cy="30" r="4" fill="#000"/>
-  <circle cx="42" cy="30" r="4" fill="#000"/>
+  <circle cx="22" cy="30" r="5" fill="#FFF"/>
+  <circle cx="22" cy="30" r="2" fill="#000"/>
+  <circle cx="42" cy="30" r="5" fill="#FFF"/>
+  <circle cx="42" cy="30" r="2" fill="#000"/>
   <path d="M20 38 q12 16 24 0" stroke="#000" stroke-width="3" fill="#FF6F61" stroke-linecap="round"/>
 </svg>

--- a/img/boy_sad.svg
+++ b/img/boy_sad.svg
@@ -1,7 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <circle cx="32" cy="32" r="30" fill="#FFE0BD" stroke="#000" stroke-width="2"/>
   <path d="M10 18 Q32 -6 54 18" fill="#333"/>
-  <circle cx="22" cy="30" r="4" fill="#000"/>
-  <circle cx="42" cy="30" r="4" fill="#000"/>
+  <circle cx="22" cy="30" r="5" fill="#FFF"/>
+  <circle cx="22" cy="30" r="2" fill="#000"/>
+  <circle cx="42" cy="30" r="5" fill="#FFF"/>
+  <circle cx="42" cy="30" r="2" fill="#000"/>
   <path d="M20 48 q12 -8 24 0" stroke="#000" stroke-width="3" fill="none" stroke-linecap="round"/>
 </svg>

--- a/img/boy_smile.svg
+++ b/img/boy_smile.svg
@@ -1,7 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <circle cx="32" cy="32" r="30" fill="#FFE0BD" stroke="#000" stroke-width="2"/>
   <path d="M10 18 Q32 -6 54 18" fill="#333"/>
-  <circle cx="22" cy="30" r="4" fill="#000"/>
-  <circle cx="42" cy="30" r="4" fill="#000"/>
+  <circle cx="22" cy="30" r="5" fill="#FFF"/>
+  <circle cx="22" cy="30" r="2" fill="#000"/>
+  <circle cx="42" cy="30" r="5" fill="#FFF"/>
+  <circle cx="42" cy="30" r="2" fill="#000"/>
   <path d="M20 40 q12 8 24 0" stroke="#000" stroke-width="3" fill="none" stroke-linecap="round"/>
 </svg>

--- a/img/girl_angry.svg
+++ b/img/girl_angry.svg
@@ -3,8 +3,10 @@
   <path d="M2 20 q30 -20 60 0 v12 H2z" fill="#A0522D"/>
   <circle cx="10" cy="34" r="6" fill="#A0522D"/>
   <circle cx="54" cy="34" r="6" fill="#A0522D"/>
-  <circle cx="22" cy="30" r="4" fill="#000"/>
-  <circle cx="42" cy="30" r="4" fill="#000"/>
+  <circle cx="22" cy="30" r="5" fill="#FFF"/>
+  <circle cx="22" cy="30" r="2" fill="#000"/>
+  <circle cx="42" cy="30" r="5" fill="#FFF"/>
+  <circle cx="42" cy="30" r="2" fill="#000"/>
   <path d="M18 24 l8 -4" stroke="#000" stroke-width="3" stroke-linecap="round"/>
   <path d="M46 24 l-8 -4" stroke="#000" stroke-width="3" stroke-linecap="round"/>
   <path d="M20 48 q12 -8 24 0" stroke="#000" stroke-width="3" fill="none" stroke-linecap="round"/>

--- a/img/girl_calm.svg
+++ b/img/girl_calm.svg
@@ -3,7 +3,9 @@
   <path d="M2 20 q30 -20 60 0 v12 H2z" fill="#A0522D"/>
   <circle cx="10" cy="34" r="6" fill="#A0522D"/>
   <circle cx="54" cy="34" r="6" fill="#A0522D"/>
-  <circle cx="22" cy="30" r="4" fill="#000"/>
-  <circle cx="42" cy="30" r="4" fill="#000"/>
+  <circle cx="22" cy="30" r="5" fill="#FFF"/>
+  <circle cx="22" cy="30" r="2" fill="#000"/>
+  <circle cx="42" cy="30" r="5" fill="#FFF"/>
+  <circle cx="42" cy="30" r="2" fill="#000"/>
   <line x1="22" y1="44" x2="42" y2="44" stroke="#000" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/img/girl_joy.svg
+++ b/img/girl_joy.svg
@@ -3,7 +3,9 @@
   <path d="M2 20 q30 -20 60 0 v12 H2z" fill="#A0522D"/>
   <circle cx="10" cy="34" r="6" fill="#A0522D"/>
   <circle cx="54" cy="34" r="6" fill="#A0522D"/>
-  <circle cx="22" cy="30" r="4" fill="#000"/>
-  <circle cx="42" cy="30" r="4" fill="#000"/>
+  <circle cx="22" cy="30" r="5" fill="#FFF"/>
+  <circle cx="22" cy="30" r="2" fill="#000"/>
+  <circle cx="42" cy="30" r="5" fill="#FFF"/>
+  <circle cx="42" cy="30" r="2" fill="#000"/>
   <path d="M20 38 q12 16 24 0" stroke="#000" stroke-width="3" fill="#FF6F61" stroke-linecap="round"/>
 </svg>

--- a/img/girl_sad.svg
+++ b/img/girl_sad.svg
@@ -3,7 +3,9 @@
   <path d="M2 20 q30 -20 60 0 v12 H2z" fill="#A0522D"/>
   <circle cx="10" cy="34" r="6" fill="#A0522D"/>
   <circle cx="54" cy="34" r="6" fill="#A0522D"/>
-  <circle cx="22" cy="30" r="4" fill="#000"/>
-  <circle cx="42" cy="30" r="4" fill="#000"/>
+  <circle cx="22" cy="30" r="5" fill="#FFF"/>
+  <circle cx="22" cy="30" r="2" fill="#000"/>
+  <circle cx="42" cy="30" r="5" fill="#FFF"/>
+  <circle cx="42" cy="30" r="2" fill="#000"/>
   <path d="M20 48 q12 -8 24 0" stroke="#000" stroke-width="3" fill="none" stroke-linecap="round"/>
 </svg>

--- a/img/girl_smile.svg
+++ b/img/girl_smile.svg
@@ -3,7 +3,9 @@
   <path d="M2 20 q30 -20 60 0 v12 H2z" fill="#A0522D"/>
   <circle cx="10" cy="34" r="6" fill="#A0522D"/>
   <circle cx="54" cy="34" r="6" fill="#A0522D"/>
-  <circle cx="22" cy="30" r="4" fill="#000"/>
-  <circle cx="42" cy="30" r="4" fill="#000"/>
+  <circle cx="22" cy="30" r="5" fill="#FFF"/>
+  <circle cx="22" cy="30" r="2" fill="#000"/>
+  <circle cx="42" cy="30" r="5" fill="#FFF"/>
+  <circle cx="42" cy="30" r="2" fill="#000"/>
   <path d="M20 40 q12 8 24 0" stroke="#000" stroke-width="3" fill="none" stroke-linecap="round"/>
 </svg>


### PR DESCRIPTION
## Summary
- Replace solid black eyes with white eyeballs and small pupils across student SVGs for a friendlier look

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dd069c8488330b40b24344e382972