### PR TITLE
feat: optimize mobile layout with comment popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,9 +37,6 @@
                 </div>
             </div>
 
-            <div class="reaction-area">
-                <div id="reaction-message" class="reaction-message"></div>
-            </div>
         </div>
 
         <div id="result-screen" class="screen hidden">
@@ -62,6 +59,10 @@
             <button id="restart-btn" class="big-button">もう一度遊ぶ</button>
             <button id="title-btn" class="big-button">タイトルに戻る</button>
         </div>
+    </div>
+
+    <div id="comment-popup" class="popup hidden">
+        <div id="reaction-message" class="reaction-message"></div>
     </div>
 
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -107,6 +107,7 @@ const servedElement = document.getElementById('served');
 const currentStudentElement = document.getElementById('current-student');
 const menuButtonsElement = document.getElementById('menu-buttons');
 const reactionMessageElement = document.getElementById('reaction-message');
+const commentPopup = document.getElementById('comment-popup');
 
 // 結果画面要素
 const finalScoreElement = document.getElementById('final-score');
@@ -197,7 +198,6 @@ function nextStudent() {
   currentStudentElement.innerHTML = `
       <div class="student-face"><img src="img/${genderPrefix}_${gameState.currentStudent.face}.svg" alt="${gameState.currentStudent.face}"></div>
       <div class="student-name">${gameState.currentStudent.name}</div>
-      <div class="student-comment">「${gameState.currentStudent.comment}」</div>
       <div class="student-preferences">
           <div class="likes">好き：${gameState.currentStudent.likes}</div>
           <div class="dislikes">嫌い：${gameState.currentStudent.dislikes}</div>
@@ -207,6 +207,27 @@ function nextStudent() {
   // リアクションメッセージをクリア
   reactionMessageElement.textContent = '';
   reactionMessageElement.className = 'reaction-message'; // スタイルもリセット
+}
+
+// コメントポップアップ表示
+function showCommentPopup(text, faceSrc, reactionClass) {
+    reactionMessageElement.textContent = text;
+    reactionMessageElement.className = 'reaction-message';
+    if (reactionClass) reactionMessageElement.classList.add(reactionClass);
+    if (faceSrc) {
+        const img = document.createElement('img');
+        img.src = faceSrc;
+        img.alt = '';
+        reactionMessageElement.appendChild(img);
+    }
+    commentPopup.classList.remove('hidden');
+    setTimeout(() => {
+        commentPopup.classList.add('hidden');
+        reactionMessageElement.textContent = '';
+        if (gameState.isGameRunning) {
+            nextStudent();
+        }
+    }, 1000);
 }
 
 // 選択されたメニューに対する処理
@@ -274,24 +295,16 @@ function selectMenu(selectedMenu) {
     gameState.served++;
     updateUI();
 
-    reactionMessageElement.textContent = reactionText;
-    reactionMessageElement.className = 'reaction-message';
-    reactionMessageElement.classList.add(reactionClass);
-    const faceImg = document.createElement('img');
-    faceImg.src = `img/${genderPrefix}_${reactionFace}.svg`;
-    faceImg.alt = reactionFace;
-    reactionMessageElement.appendChild(faceImg);
+    const faceImgSrc = `img/${genderPrefix}_${reactionFace}.svg`;
 
     // 生徒カードの表情も更新
     const studentFaceImg = currentStudentElement.querySelector('.student-face img');
     if (studentFaceImg) {
-        studentFaceImg.src = faceImg.src;
+        studentFaceImg.src = faceImgSrc;
         studentFaceImg.alt = reactionFace;
     }
 
-    setTimeout(() => {
-        nextStudent();
-    }, 1000);
+    showCommentPopup(reactionText, faceImgSrc, reactionClass);
 }
 
 

--- a/style.css
+++ b/style.css
@@ -88,6 +88,7 @@ body {
   display: flex;
   flex-direction: column;
   height: 100vh;
+  overflow: hidden;
 }
 
 .game-header {
@@ -280,6 +281,24 @@ body {
   border: 2px solid #AD1457;
 }
 
+/* コメントポップアップ */
+.popup {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.popup.hidden {
+  display: none;
+}
+
 @keyframes pop {
   0% { transform: scale(1); }
   50% { transform: scale(1.1); }
@@ -368,42 +387,39 @@ body {
       gap: 15px;
       margin-bottom: 10px;
   }
-  
+
   .student-area,
   .menu-selection {
+      flex: 1;
       min-width: auto;
-      max-width: 100%; /* スマホでは全幅に */
+      max-width: 100%;
   }
-  
+
+  .menu-selection {
+      overflow-y: auto;
+  }
+
   .student-card {
       padding: 15px;
   }
-  
+
   .student-face img {
       width: 3em;
       height: 3em;
   }
-  
+
   .student-name {
       font-size: 1.3em;
   }
-  
-  .student-comment {
-      font-size: 1em;
-  }
-  
+
   .menu-buttons-grid {
       grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
       gap: 8px;
   }
-  
+
   .menu-button {
       padding: 10px 6px;
       font-size: 0.8em;
-  }
-
-  .reaction-area {
-      min-height: 50px;
   }
   
   .result-stats {
@@ -424,20 +440,16 @@ body {
   .screen {
       padding: 15px;
   }
-  
+
   .student-face img {
       width: 2.5em;
       height: 2.5em;
   }
-  
+
   .student-name {
       font-size: 1.2em;
   }
-  
-  .student-comment {
-      font-size: 0.9em;
-  }
-  
+
   .menu-buttons-grid {
       grid-template-columns: repeat(2, 1fr);
   }
@@ -447,7 +459,4 @@ body {
       font-size: 1.1em;
   }
 
-  .reaction-area {
-      min-height: 40px;
-  }
 }


### PR DESCRIPTION
## Summary
- adjust game screen layout for mobile with student area stacked above menu options
- add full-screen popup to show student reactions and advance to next student
- refactor JavaScript to drive new popup and remove inline comments

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689047fe327c8330b0026bea1afb99fb