### PR TITLE
Enable horizontal scroll on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,15 +17,15 @@ body {
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
+  overflow-x: auto;
 }
 
 .game-container {
-  max-width: 800px;
-  width: 100%;
+  width: 800px;
+  min-width: 800px;
   background: white;
   border-radius: 20px;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-  overflow: hidden;
 }
 
 /* 画面管理 */


### PR DESCRIPTION
## Summary
- Fix game container width at 800px so mobile users scroll horizontally instead of shrinking layout
- Allow horizontal scrolling on body

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891c8b6b46c833088c161fa62eaa989