### PR TITLE
Improve mobile layout for school lunch game

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,15 +17,17 @@ body {
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  overflow-x: auto;
+  overflow-x: hidden;
 }
 
 .game-container {
-  width: 800px;
-  min-width: 800px;
+  width: 100%;
+  max-width: 800px;
   background: white;
   border-radius: 20px;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+  margin: 0 auto;
+  padding: 10px;
 }
 
 .game-instructions {
@@ -212,7 +214,7 @@ body {
 
 .menu-buttons-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 10px;
 }
 
@@ -224,9 +226,10 @@ body {
   cursor: pointer;
   transition: all 0.3s ease;
   text-align: center;
-  font-size: 0.9em;
+  font-size: 1em;
   font-weight: bold;
   color: #333;
+  min-height: 44px;
 }
 
 .menu-button:hover {
@@ -362,13 +365,16 @@ body {
   }
   
   .score-info {
-      justify-content: center;
-      gap: 10px;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
   }
-  
+
   .score-info span {
       padding: 6px 12px;
       font-size: 0.9em;
+      width: 100%;
+      text-align: center;
   }
   
   /* .today-menu は削除されたので、このメディアクエリ内からも削除します */
@@ -395,21 +401,25 @@ body {
   }
   
   .student-name {
-      font-size: 1.3em;
+      font-size: 1.4em;
+      margin-bottom: 8px;
   }
-  
+
   .student-comment {
-      font-size: 1em;
+      font-size: 1.1em;
+      line-height: 1.6;
+      margin-bottom: 12px;
   }
   
   .menu-buttons-grid {
-      grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
       gap: 8px;
   }
-  
+
   .menu-button {
       padding: 10px 6px;
-      font-size: 0.8em;
+      font-size: 0.95em;
+      min-height: 44px;
   }
 
   .reaction-area {
@@ -441,15 +451,20 @@ body {
   }
   
   .student-name {
-      font-size: 1.2em;
+      font-size: 1.3em;
   }
-  
+
   .student-comment {
-      font-size: 0.9em;
+      font-size: 1em;
+      line-height: 1.5;
   }
   
   .menu-buttons-grid {
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(2, 1fr);
+  }
+
+  .menu-button {
+      font-size: 1em;
   }
   
   .big-button {
@@ -459,5 +474,11 @@ body {
 
   .reaction-area {
       min-height: 40px;
+  }
+}
+
+@media (max-width: 360px) {
+  .menu-buttons-grid {
+      grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- Make game container responsive and prevent horizontal scrolling
- Stack header stats vertically on narrow screens
- Tweak fonts and menu buttons for readability and touch-friendliness on phones

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6894738792bc8330aa67659997798fd4