### PR TITLE
Adjust menu button size and spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -207,7 +207,7 @@ body {
 .menu-buttons-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 10px;
+  gap: 5px;
   flex: 1;
 }
 
@@ -222,7 +222,7 @@ body {
   font-size: 1em;
   font-weight: bold;
   color: #333;
-  min-height: 44px;
+  height: 35%;
 }
 
 .menu-button:hover {
@@ -427,13 +427,13 @@ body {
   
     .menu-buttons-grid {
         grid-template-columns: repeat(3, 1fr);
-        gap: 8px;
+        gap: 5px;
     }
 
     .menu-button {
         padding: 5px 6px;
         font-size: 0.95em;
-        min-height: 22px;
+        height: 35%;
     }
 
   .reaction-area {


### PR DESCRIPTION
## Summary
- set menu buttons to a 35% height and tightened their grid gap for a more compact layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896c17672d88330bae217218307c600