### PR TITLE
Fix scroll and menu button spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -15,7 +15,7 @@ body {
 
 .game-container {
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
   background: white;
   margin: 0 auto;
   padding: 10px;
@@ -90,7 +90,6 @@ body {
   /* スマホでスクロールせずにコメントを見られるように調整 */
   display: flex;
   flex-direction: column;
-  height: 100vh;
 }
 
 .game-header {
@@ -124,14 +123,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 10px;
-  flex: 1 1 auto;
 }
 
-.student-area {
-  flex: 0 0 30%;
-  max-height: 30%;
-  overflow-y: auto;
-}
 
 .student-card {
   background: linear-gradient(135deg, #E8F5E8 0%, #F0FFF0 100%);
@@ -189,9 +182,6 @@ body {
 
 
 .menu-selection {
-  flex: 1;
-  max-height: 70%;
-  overflow-y: auto;
   display: flex;
   flex-direction: column;
 }
@@ -207,8 +197,7 @@ body {
 .menu-buttons-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 5px;
-  flex: 1;
+  gap: 2px;
 }
 
 .menu-button {
@@ -222,7 +211,6 @@ body {
   font-size: 1em;
   font-weight: bold;
   color: #333;
-  height: 35%;
 }
 
 .menu-button:hover {
@@ -427,13 +415,12 @@ body {
   
     .menu-buttons-grid {
         grid-template-columns: repeat(3, 1fr);
-        gap: 5px;
+        gap: 2px;
     }
 
     .menu-button {
         padding: 5px 6px;
         font-size: 0.95em;
-        height: 35%;
     }
 
   .reaction-area {


### PR DESCRIPTION
## Summary
- Allow game screen to expand by removing forced heights and overflow
- Compress lunch menu buttons by removing fixed heights and reducing grid gap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68971a4b79c0833094db64458b254996