### PR TITLE
Add nine lunch choices and remove scroll from student dialog

### DIFF
--- a/main.js
+++ b/main.js
@@ -172,7 +172,8 @@ function generateMenuOptions(student) {
   const options = [student.likes, student.dislikes];
   const otherMenus = menuItems.filter(m => m !== student.likes && m !== student.dislikes);
   const shuffled = [...otherMenus].sort(() => Math.random() - 0.5);
-  options.push(...shuffled.slice(0, 4));
+  // 合計9品になるようにランダムなメニューを7つ追加
+  options.push(...shuffled.slice(0, 7));
   return options.sort(() => Math.random() - 0.5);
 }
 

--- a/style.css
+++ b/style.css
@@ -15,7 +15,7 @@ body {
 
 .game-container {
   width: 100%;
-  min-height: 100vh;
+  height: 100vh; /* 画面内に収める */
   background: white;
   margin: 0 auto;
   padding: 10px;
@@ -90,6 +90,8 @@ body {
   /* スマホでスクロールせずにコメントを見られるように調整 */
   display: flex;
   flex-direction: column;
+  height: 100%;
+  overflow: hidden; /* 画面内に収める */
 }
 
 .game-header {
@@ -123,6 +125,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  flex: 1; /* 残りの高さを占有 */
+  justify-content: space-between;
 }
 
 
@@ -184,6 +188,7 @@ body {
 .menu-selection {
   display: flex;
   flex-direction: column;
+  flex: 1; /* メニューを画面内に収める */
 }
 
 .menu-selection h3 {
@@ -197,7 +202,10 @@ body {
 .menu-buttons-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr); /* 3x3 のグリッド */
   gap: 2px;
+  flex: 1;
+  height: 100%;
 }
 
 .menu-button {


### PR DESCRIPTION
## Summary
- Show nine menu buttons per student
- Restructure game screen to fit within viewport and prevent scrolling

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_6897f48dba5c833088e4f5ce42e6b237