### PR TITLE
Improve mobile scaling for play screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,7 +352,8 @@
     fit.style.setProperty('paddingRight', `${(vw-sw*scale)/2}px`);
     fit.style.setProperty('paddingTop', `${(vh-sh*scale)/2}px`);
     fit.style.setProperty('paddingBottom', `${(vh-sh*scale)/2}px`);
-    document.documentElement.style.setProperty('--fs', settings.font);
+    const fontScale = settings.font / scale;
+    document.documentElement.style.setProperty('--fs', fontScale);
     document.body.classList.toggle('contrast', settings.contrast);
   }
   window.addEventListener('resize', applyScale);


### PR DESCRIPTION
## Summary
- Adjust font scaling based on viewport scale so text remains legible on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c022c6dee08330b9264f6ca8fca41a