### PR TITLE
fix: improve landscape layout on phones

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     --w:1280; --h:720; --fs:1; /* scale factor for font */
   }
   *{box-sizing:border-box}
-  html,body{height:100%;}
+    html,body{height:100%;min-height:100vh;}
   body{margin:0;background:#111;color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Hiragino Sans","Noto Sans JP",system-ui,Segoe UI,Roboto;}
   /* Letterbox scaling container */
   .fitbox{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:#111;}
@@ -69,11 +69,19 @@
   .board{position:absolute;left:0;top:64px;width:1280px;height:100px;background:linear-gradient(180deg, #1B3A2B 0, #1B3A2B 70px, transparent 70px);}
   /* Result board canvas */
   #chalk{position:absolute;left:0;top:0;width:1280px;height:720px;pointer-events:none}
-  /* Responsive vertical stack for tall screens (handled by scale, but also reflow aid) */
-  @media (max-aspect-ratio: 9/16){
-    .main{grid-template-columns:1fr;grid-template-rows:260px 260px 1fr;grid-template-areas:"stand" "talk" "menu"}
-  }
-</style>
+    /* Responsive vertical stack for tall screens (handled by scale, but also reflow aid) */
+    @media (max-aspect-ratio: 9/16){
+      .main{grid-template-columns:1fr;grid-template-rows:260px 260px 1fr;grid-template-areas:"stand" "talk" "menu"}
+    }
+    /* Landscape phones */
+    @media (orientation: landscape) and (max-height: 450px){
+      header{height:56px;}
+      .board{top:56px;}
+      .main{top:56px;height:664px;}
+      .grid{gap:12px;}
+      .cell{height:64px;}
+    }
+  </style>
 </head>
 <body>
 <div class="fitbox" id="fit">
@@ -264,7 +272,7 @@
   'use strict';
   /* ================= CONFIG ================= */
   const CONFIG={
-    BASE_W:1280, BASE_H:720, MIN_W:360, MIN_H:640, MAX_W:1920, MAX_H:1080,
+    BASE_W:1280, BASE_H:720, MIN_W:360, MIN_H:360, MAX_W:1920, MAX_H:1080,
     COLORS:{bg:'#F7F3E8', board:'#1B3A2B', chalk:'#F9F9F9', wood:'#A8753B', text:'#222', accent:'#0C63E4'},
     TIMER_OPTIONS:[6,8,10,12], DEFAULT_TIMER:10,
     FONT_SCALE:1, CONTRAST:false,


### PR DESCRIPTION
## Summary
- ensure body uses viewport height and add landscape-specific CSS tweaks
- allow scaling to smaller heights by lowering minimum height constraint

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c025ec315c83309df5d75ae23fabe9